### PR TITLE
Fixed ExclusiveStartKey handling

### DIFF
--- a/lib/fake_dynamo/attribute.rb
+++ b/lib/fake_dynamo/attribute.rb
@@ -58,6 +58,22 @@ module FakeDynamo
         @value <=> other.value
       end
     end
+    
+    def <=(other)
+      if @type == 'N'
+        @value.to_f <= other.value.to_f
+      else
+        @value <= other.value
+      end
+    end    
+    
+    def >=(other)
+      if @type == 'N'
+        @value.to_f >= other.value.to_f
+      else
+        @value >= other.value
+      end
+    end    
 
     def eql?(attribute)
       return false unless attribute.kind_of? Attribute

--- a/spec/fake_dynamo/table_spec.rb
+++ b/spec/fake_dynamo/table_spec.rb
@@ -373,7 +373,8 @@ module FakeDynamo
         t = Table.new(data)
         t.put_item(item)
         (1..3).each do |i|
-          (1..10).each do |j|
+          (1..15).each do |j|
+            next if j.even?
             item['Item']['AttributeName1']['S'] = "att#{i}"
             item['Item']['AttributeName2']['N'] = j.to_s
             t.put_item(item)
@@ -422,14 +423,14 @@ module FakeDynamo
 
       it 'should handle scanindexforward' do
         result = subject.query(query)
-        result['Items'].first['AttributeName2'].should eq({'N' => '2'})
+        result['Items'].first['AttributeName2'].should eq({'N' => '3'})
         result = subject.query(query.merge({'ScanIndexForward' => false}))
-        result['Items'].first['AttributeName2'].should eq({'N' => '10'})
+        result['Items'].first['AttributeName2'].should eq({'N' => '15'})
       end
 
       it 'should return lastevaluated key' do
         result = subject.query(query)
-        result['LastEvaluatedKey'].should == {"HashKeyElement"=>{"S"=>"att1"}, "RangeKeyElement"=>{"N"=>"6"}}
+        result['LastEvaluatedKey'].should == {"HashKeyElement"=>{"S"=>"att1"}, "RangeKeyElement"=>{"N"=>"11"}}
         result = subject.query(query.merge('Limit' => 100))
         result['LastEvaluatedKey'].should be_nil
 
@@ -439,9 +440,9 @@ module FakeDynamo
       end
 
       it 'should handle exclusive start key' do
-        result = subject.query(query.merge({'ExclusiveStartKey' => {"HashKeyElement"=>{"S"=>"att1"}, "RangeKeyElement"=>{"N"=>"6"}}}))
+        result = subject.query(query.merge({'ExclusiveStartKey' => {"HashKeyElement"=>{"S"=>"att1"}, "RangeKeyElement"=>{"N"=>"7"}}}))
         result['Count'].should eq(4)
-        result['Items'].first['AttributeName2'].should eq({'N' => '7'})
+        result['Items'].first['AttributeName2'].should eq({'N' => '9'})
         result = subject.query(query.merge({'ExclusiveStartKey' => {"HashKeyElement"=>{"S"=>"att1"}, "RangeKeyElement"=>{"N"=>"88"}}}))
         result['Count'].should eq(0)
         result['Items'].should be_empty
@@ -455,7 +456,7 @@ module FakeDynamo
 
       it 'should handle between operator' do
         query['RangeKeyCondition'] = {
-          'AttributeValueList' => [{'N' => '1'}, {'N' => '4'}],
+          'AttributeValueList' => [{'N' => '1'}, {'N' => '7'}],
             'ComparisonOperator' => 'BETWEEN'
         }
         result = subject.query(query)
@@ -466,7 +467,7 @@ module FakeDynamo
         query['AttributesToGet'] = ['AttributeName1', "AttributeName2"]
         result = subject.query(query)
         result['Items'].first.should eq('AttributeName1' => { 'S' => 'att1'},
-                                        'AttributeName2' => { 'N' => '2' })
+                                        'AttributeName2' => { 'N' => '3' })
       end
     end
 
@@ -474,7 +475,8 @@ module FakeDynamo
       subject do
         t = Table.new(data)
         (1..3).each do |i|
-          (1..10).each do |j|
+          (1..15).each do |j|
+            next if j.even?
             item['Item']['AttributeName1']['S'] = "att#{i}"
             item['Item']['AttributeName2']['N'] = j.to_s
             t.put_item(item)
@@ -509,7 +511,7 @@ module FakeDynamo
 
       it 'should handle basic scan' do
         result = subject.scan(scan)
-        result['Count'].should eq(30)
+        result['Count'].should eq(24)
 
         scan['ScanFilter']['AttributeName2']['ComparisonOperator'] = 'EQ'
         subject.scan(scan)['Count'].should eq(3)
@@ -518,7 +520,7 @@ module FakeDynamo
       it 'should return lastevaluated key' do
         scan['Limit'] = 5
         result = subject.scan(scan)
-        result['LastEvaluatedKey'].should == {"HashKeyElement"=>{"S"=>"att1"}, "RangeKeyElement"=>{"N"=>"5"}}
+        result['LastEvaluatedKey'].should == {"HashKeyElement"=>{"S"=>"att1"}, "RangeKeyElement"=>{"N"=>"9"}}
         result = subject.scan(scan.merge('Limit' => 100))
         result['LastEvaluatedKey'].should be_nil
 

--- a/spec/fake_dynamo/table_spec.rb
+++ b/spec/fake_dynamo/table_spec.rb
@@ -442,6 +442,9 @@ module FakeDynamo
       it 'should handle exclusive start key' do
         result = subject.query(query.merge({'ExclusiveStartKey' => {"HashKeyElement"=>{"S"=>"att1"}, "RangeKeyElement"=>{"N"=>"7"}}}))
         result['Count'].should eq(4)
+        result['Items'].first['AttributeName2'].should eq({'N' => '9'})        
+        result = subject.query(query.merge({'ExclusiveStartKey' => {"HashKeyElement"=>{"S"=>"att1"}, "RangeKeyElement"=>{"N"=>"8"}}}))
+        result['Count'].should eq(4)
         result['Items'].first['AttributeName2'].should eq({'N' => '9'})
         result = subject.query(query.merge({'ExclusiveStartKey' => {"HashKeyElement"=>{"S"=>"att1"}, "RangeKeyElement"=>{"N"=>"88"}}}))
         result['Count'].should eq(0)


### PR DESCRIPTION
Hi,

I noticed that a Query operation would return an empty result if the ExclusiveStartKey was not present (the != comparison in drop_till_start would drop all previously matched items). I made the test data a little sparse so it would cover this scenario.

Thanks for publishing this project!
Paul
