### PR TITLE
Allow binary keys

### DIFF
--- a/lib/fake_dynamo/attribute.rb
+++ b/lib/fake_dynamo/attribute.rb
@@ -5,7 +5,7 @@ module FakeDynamo
     def initialize(name, value, type)
       @name, @value, @type = name, value, type
 
-      if @type == 'B'
+      if @type == 'B' and value
         @value = Base64.decode64(value)
       end
 


### PR DESCRIPTION
If you create a table with binary keys then the attribute value will be nil
