### PR TITLE
Set default bind address

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,13 @@ starting the server. Because of the way fake_dynamo stores the data,
 file size tend to grow by time. so fake_dynamo will compact the database
 during start up if the file size is greater than 100mb. you can
 manually compact it by passing --compact flag.
+
+## Guardfile
+You can use the [guard-process](https://rubygems.org/gems/guard-process) gem with guard to run fake_dynamo along with
+your other development environment
+
+```ruby
+guard 'process', :name => 'FakeDynamo', :command => 'fake_dynamo' do
+  watch('Gemfile.lock')
+end
+```

--- a/bin/fake_dynamo
+++ b/bin/fake_dynamo
@@ -4,12 +4,16 @@ $:.unshift(File.dirname(__FILE__) + '/../lib')
 require 'fake_dynamo'
 require 'optparse'
 
-options = { :port => 4567, :compact => false, :db => '/usr/local/var/fake_dynamo/db.fdb' }
+options = { :port => 4567, :bind => '127.0.0.1', :compact => false, :db => '/usr/local/var/fake_dynamo/db.fdb' }
 OptionParser.new do |opts|
   opts.banner = "Usage: fake_dynamo [options]"
 
   opts.on("-p", "--port PORT", "Default: #{options[:port]}") do |v|
     options[:port] = v
+  end
+
+  opts.on("-b", "--bind ADDR", "Default: #{options[:bind]}") do |v|
+    options[:bind] = v
   end
 
   opts.on("-d", "--db PATH", "Default: #{options[:db]}") do |v|
@@ -56,7 +60,7 @@ if options[:compact]
 end
 
 FakeDynamo::Storage.instance.load_aof
-FakeDynamo::Server.run!(:port => options[:port])
+FakeDynamo::Server.run!(:port => options[:port], :bind => options[:bind])
 
 at_exit {
   FakeDynamo::Storage.instance.shutdown


### PR DESCRIPTION
Under server implementations like WEBrick, the default bind address is 0.0.0.0, which can be dangerous in a public environment.  

This pull request adds a CLI option to set the bind address, but defaults it to 127.0.0.1.
