### PR TITLE
Local Secondary Index fixes

### DIFF
--- a/lib/fake_dynamo/key.rb
+++ b/lib/fake_dynamo/key.rb
@@ -3,7 +3,7 @@ module FakeDynamo
     include Comparable
     extend Validation
 
-    attr_accessor :primary, :range
+    attr_accessor :primary, :range, :tertiary
 
     class << self
       def from_data(key_data, key_schema)
@@ -28,6 +28,28 @@ module FakeDynamo
         key
       end
 
+      # local secondary indexes have a three part key:
+      # hash key -> primary
+      # index range key -> range
+      # table range key -> tertiary
+      def from_index_schema(data, index_schema, table_schema)
+        key = Key.new
+        validate_key_schema(data, index_schema)
+        validate_key_schema(data, table_schema)
+        key.primary = create_attribute(index_schema.hash_key, data)
+        key.range = create_attribute(index_schema.range_key, data)
+        key.tertiary = create_attribute(table_schema.range_key, data)
+        key
+      end
+
+      def from_index_item(item, key_schema)
+        key = Key.new
+        key.primary = item.key.primary
+        key.range = item[key_schema.range_key.name]
+        key.tertiary = item.key.range
+        key
+      end
+
       def create_attribute(key, data)
         name = key.name
         attr = Attribute.from_hash(name, data[name])
@@ -45,11 +67,12 @@ module FakeDynamo
       return false unless key.kind_of? Key
 
       @primary == key.primary &&
-        @range == key.range
+        @range == key.range &&
+        @tertiary == key.tertiary
     end
 
     def hash
-      primary.hash ^ range.hash
+      primary.hash ^ range.hash ^ tertiary.hash
     end
 
     def as_hash
@@ -57,11 +80,14 @@ module FakeDynamo
       if @range
         result.merge!(@range.as_hash)
       end
+      if @tertiary
+        result.merge!(@tertiary.as_hash)
+      end
       result
     end
 
     def <=>(other)
-      [primary, range] <=> [other.primary, other.range]
+      [primary, range, tertiary] <=> [other.primary, other.range, other.tertiary]
     end
 
   end

--- a/lib/fake_dynamo/table.rb
+++ b/lib/fake_dynamo/table.rb
@@ -250,7 +250,11 @@ module FakeDynamo
       merge_items(response, data, results, index)
 
       if last_evaluated_item
-        response['LastEvaluatedKey'] = last_evaluated_item.key.as_hash
+        if index
+          response['LastEvaluatedKey'] = Key.from_index_item(last_evaluated_item, schema).as_hash
+        else
+          response['LastEvaluatedKey'] = last_evaluated_item.key.as_hash
+        end
       end
       response
     end


### PR DESCRIPTION
Fix Query with an index to sort based on the requested index.
Fix LastEvaluatedKey/ExclusiveStartKey on index queries to have three elements. Since the index range key is not required to be unique, this is how DynamoDB keys local secondary indexes.
