### PR TITLE
Adding responds_to to allow usage with Thin

### DIFF
--- a/bin/fake_dynamo
+++ b/bin/fake_dynamo
@@ -67,7 +67,7 @@ end
 
 FakeDynamo::Storage.instance.load_aof
 FakeDynamo::Server.run!(:port => options[:port], :bind => options[:bind]) do |server|
-  server.config[:AccessLog] = []
+  server.config[:AccessLog] = [] if server.config.respond_to?('[]=')
 end
 
 at_exit {


### PR DESCRIPTION
There's strange behavior where server.config would equal 1024 when running
fake_dynamo under thin, a superior web server, instead of the, frankly
terrible, WEBrick. This is a stop-gap fix that allows thin to run unhinged.
