### PR TITLE
Use correct version for exceptions

### DIFF
--- a/lib/fake_dynamo/exceptions.rb
+++ b/lib/fake_dynamo/exceptions.rb
@@ -3,7 +3,7 @@ module FakeDynamo
 
     class_attribute :description, :type, :status
 
-    self.type = 'com.amazon.dynamodb.v20120810'
+    self.type = 'com.amazonaws.dynamodb.v20120810'
     self.status = 400
 
     attr_reader :detail

--- a/lib/fake_dynamo/exceptions.rb
+++ b/lib/fake_dynamo/exceptions.rb
@@ -3,7 +3,7 @@ module FakeDynamo
 
     class_attribute :description, :type, :status
 
-    self.type = 'com.amazon.dynamodb.v20111205'
+    self.type = 'com.amazon.dynamodb.v20120810'
     self.status = 400
 
     attr_reader :detail


### PR DESCRIPTION
I noticed exceptions are still served with the old DDB version.
