### PR TITLE
Remove range_key query restriction

### DIFF
--- a/lib/fake_dynamo/table.rb
+++ b/lib/fake_dynamo/table.rb
@@ -646,7 +646,6 @@ module FakeDynamo
         @global_secondary_indexes = global_indexes_data.map do |index|
           GlobalSecondaryIndex.from_data(index, data['AttributeDefinitions'], @key_schema)
         end
-        validate_range_key(key_schema)
       end
     end
 

--- a/lib/fake_dynamo/table.rb
+++ b/lib/fake_dynamo/table.rb
@@ -221,7 +221,6 @@ module FakeDynamo
     end
 
     def query(data)
-      range_key_present
       select_and_attributes_to_get_present?(data)
       validate_limit(data)
 
@@ -666,12 +665,6 @@ module FakeDynamo
 
       if used_keys.uniq.size != attribute_keys.size
         raise ValidationException, "Some AttributeDefinitions are not used AttributeDefinitions: #{attribute_keys.inspect}, keys used: #{used_keys.inspect}"
-      end
-    end
-
-    def range_key_present
-      unless key_schema.range_key
-        raise ValidationException, "Query can be performed only on a table with a HASH,RANGE key schema"
       end
     end
   end

--- a/spec/fake_dynamo/table_spec.rb
+++ b/spec/fake_dynamo/table_spec.rb
@@ -585,18 +585,6 @@ module FakeDynamo
         }.to raise_error(ValidationException, /count/i)
       end
 
-      it 'should not allow to query on a table without rangekey' do
-        data['KeySchema'].delete_at(1)
-        data['AttributeDefinitions'].delete_at(1)
-        data['AttributeDefinitions'].delete_at(1)
-        data.delete('LocalSecondaryIndexes')
-        data.delete('GlobalSecondaryIndexes')
-        t = Table.new(data)
-        expect {
-          t.query(query)
-        }.to raise_error(ValidationException, /key schema/)
-      end
-
       it 'should only allow limit greater than zero' do
         expect {
           subject.query(query.merge('Limit' => 0))


### PR DESCRIPTION
The [doc](http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html) says, that range_key criteria is optional:

> For a query on a table, you can only have conditions on the table primary key attributes. You must specify the hash key attribute name and value as an EQ condition. You can optionally specify a second condition, referring to the range key attribute.

This is probably left from an older protocol version. What do you think?
