### PR TITLE
Use schema from global indexes as well as local

### DIFF
--- a/lib/fake_dynamo/table.rb
+++ b/lib/fake_dynamo/table.rb
@@ -227,7 +227,7 @@ module FakeDynamo
 
       index = nil
       if index_name = data['IndexName']
-        index = local_secondary_indexes.find { |i| i.name == index_name }
+        index = (global_secondary_indexes + local_secondary_indexes).find { |i| i.name == index_name }
         raise ValidationException, "The provided starting key is invalid" unless index
         schema = index.key_schema
       else


### PR DESCRIPTION
This fixed `AWS::DynamoDB::Errors::ValidationException: Validation error detected: The provided starting key is invalid` for me.

P.S. As you can see this is my third PR, I just can't stop, but this is probably last one for a now.
Please feel free to disregard my changes or provide any suggestions if you don't think that anything is incorrect.

Thanks :sparkles: 
