### PR TITLE
Quote NULL in version 0.1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'rspec'
+  gem 'rspec', "~> 2.0"
   gem 'rack-test'
   gem 'pry'
   gem 'simplecov'

--- a/lib/fake_dynamo/api.yml
+++ b/lib/fake_dynamo/api.yml
@@ -603,7 +603,7 @@
               ComparisonOperator:
               - :string
               - :required
-              - :enum: [EQ, NE, LE, LT, GE, GT, NOT_NULL, NULL, CONTAINS, NOT_CONTAINS, BEGINS_WITH, IN, BETWEEN]
+              - :enum: [EQ, NE, LE, LT, GE, GT, NOT_NULL, "NULL", CONTAINS, NOT_CONTAINS, BEGINS_WITH, IN, BETWEEN]
       ExclusiveStartKey:
       - :structure:
           HashKeyElement:

--- a/spec/fake_dynamo/validation_spec.rb
+++ b/spec/fake_dynamo/validation_spec.rb
@@ -57,6 +57,15 @@ module FakeDynamo
           end.to raise_error(ValidationException, message)
         end
       end
+
+      it 'should allow null comparison operator' do
+        subject.validate_payload('Scan', {
+          'TableName' => 'Table1',
+          'ScanFilter' => {
+            'age' => { 'ComparisonOperator' => 'NULL' }
+          }
+        })
+      end
     end
 
   end


### PR DESCRIPTION
The latest commit on master, but backported for use with the old API.

Can you release this as 0.1.4?

Edit: Hmmm, github wants to merge this with master... It is actually based on commit 0a77c1af75fd2c1eb3d995239f55f8423639fec2.
