### PR TITLE
GlobalSecondaryIndexes does not require a range key

### DIFF
--- a/lib/fake_dynamo/table.rb
+++ b/lib/fake_dynamo/table.rb
@@ -221,7 +221,6 @@ module FakeDynamo
     end
 
     def query(data)
-      range_key_present
       select_and_attributes_to_get_present?(data)
       validate_limit(data)
 
@@ -665,12 +664,6 @@ module FakeDynamo
 
       if used_keys.uniq.size != attribute_keys.size
         raise ValidationException, "Some AttributeDefinitions are not used AttributeDefinitions: #{attribute_keys.inspect}, keys used: #{used_keys.inspect}"
-      end
-    end
-
-    def range_key_present
-      unless key_schema.range_key
-        raise ValidationException, "Query can be performed only on a table with a HASH,RANGE key schema"
       end
     end
   end

--- a/lib/fake_dynamo/table.rb
+++ b/lib/fake_dynamo/table.rb
@@ -647,7 +647,6 @@ module FakeDynamo
         @global_secondary_indexes = global_indexes_data.map do |index|
           GlobalSecondaryIndex.from_data(index, data['AttributeDefinitions'], @key_schema)
         end
-        validate_range_key(key_schema)
       end
     end
 

--- a/spec/fake_dynamo/table_spec.rb
+++ b/spec/fake_dynamo/table_spec.rb
@@ -593,18 +593,6 @@ module FakeDynamo
         }.to raise_error(ValidationException, /count/i)
       end
 
-      it 'should not allow to query on a table without rangekey' do
-        data['KeySchema'].delete_at(1)
-        data['AttributeDefinitions'].delete_at(1)
-        data['AttributeDefinitions'].delete_at(1)
-        data.delete('LocalSecondaryIndexes')
-        data.delete('GlobalSecondaryIndexes')
-        t = Table.new(data)
-        expect {
-          t.query(query)
-        }.to raise_error(ValidationException, /key schema/)
-      end
-
       it 'should only allow limit greater than zero' do
         expect {
           subject.query(query.merge('Limit' => 0))

--- a/spec/fake_dynamo/table_spec.rb
+++ b/spec/fake_dynamo/table_spec.rb
@@ -29,6 +29,14 @@ module FakeDynamo
               "ProjectionType" => "ALL"
             },
             "ProvisionedThroughput" => {"ReadCapacityUnits" => 5 ,"WriteCapacityUnits" => 10}
+          },
+          {
+            "IndexName" => "hash_only",
+            "KeySchema" => [{"AttributeName" => "score", "KeyType" => "HASH"}],
+            "Projection" => {
+              "ProjectionType" => "ALL"
+            },
+            "ProvisionedThroughput" => {"ReadCapacityUnits" => 5 ,"WriteCapacityUnits" => 10}
           }],
         "ProvisionedThroughput" => {"ReadCapacityUnits" => 5 ,"WriteCapacityUnits" => 10}
       }
@@ -772,6 +780,18 @@ module FakeDynamo
           result = subject.query(gsi_query)
           keys = result['Items'].map { |i| [i['score']['N'].to_i] }
           keys.should eq(keys.sort)
+        end
+
+        it 'should handle global index query with only hash' do
+          gsi_query['KeyConditions'] = {
+            'score' => {
+              'AttributeValueList' => [{'N' => '42'}],
+              'ComparisonOperator' => 'EQ'
+            }
+          }
+          gsi_query['IndexName'] = 'hash_only'
+          result = subject.query(gsi_query)
+          result['Items'].size.should eq(1)
         end
       end
     end


### PR DESCRIPTION
Removed the range key validation and added tests for it.

From the docs:
"Every global secondary index must have a hash key, and can have an optional range key."
http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.html
