### PR TITLE
Add rudimentary throttling simulation

### DIFF
--- a/bin/fake_dynamo
+++ b/bin/fake_dynamo
@@ -29,6 +29,10 @@ OptionParser.new do |opts|
     options[:pid] = pid
   end
 
+  opts.on "-X", "--throughput-exception", "Always throw throughput exception" do |throws|
+    options[:throws] = throws
+  end
+
   opts.on "-D", "--[no-]daemonize", "Detaches the process" do |daemonize|
     options[:daemonize] = daemonize
   end
@@ -43,10 +47,9 @@ if options[:daemonize]
   Process.daemon(true, true)
 end
 
-if ENV['throws'] == "1"
-  puts "Running in error-ful mode"
+if options[:throws]
+  puts "*** Running in error-ful mode ***"
 end
-
 
 if (pid = options[:pid])
   if File.exist?(pid)
@@ -71,7 +74,7 @@ if options[:compact]
 end
 
 FakeDynamo::Storage.instance.load_aof
-FakeDynamo::Server.run!(:port => options[:port], :bind => options[:bind]) do |server|
+FakeDynamo::Server.run!(:port => options[:port], :bind => options[:bind], :throws => options[:throws]) do |server|
   if server.respond_to?('config') && server.config.respond_to?('[]=')
     server.config[:AccessLog] = []
   end

--- a/bin/fake_dynamo
+++ b/bin/fake_dynamo
@@ -43,6 +43,11 @@ if options[:daemonize]
   Process.daemon(true, true)
 end
 
+if ENV['throws'] == "1"
+  puts "Running in error-ful mode"
+end
+
+
 if (pid = options[:pid])
   if File.exist?(pid)
     existing_pid = File.open(pid, 'r').read.chomp.to_i

--- a/lib/fake_dynamo/exceptions.rb
+++ b/lib/fake_dynamo/exceptions.rb
@@ -54,4 +54,11 @@ module FakeDynamo
   class ConditionalCheckFailedException < Error
     self.description = 'The conditional request failed'
   end
+
+  class ProvisionedThroughputExceededException < Error
+    self.type = 'com.amazonaws.dynamodb.v20111205'
+    self.description = 'The level of configured provisioned throughput for ' +
+      'the table was exceeded. Consider increasing your provisioning level ' +
+      'with the UpdateTable API'
+  end
 end

--- a/lib/fake_dynamo/exceptions.rb
+++ b/lib/fake_dynamo/exceptions.rb
@@ -56,7 +56,6 @@ module FakeDynamo
   end
 
   class ProvisionedThroughputExceededException < Error
-    self.type = 'com.amazonaws.dynamodb.v20111205'
     self.description = 'The level of configured provisioned throughput for ' +
       'the table was exceeded. Consider increasing your provisioning level ' +
       'with the UpdateTable API'

--- a/lib/fake_dynamo/server.rb
+++ b/lib/fake_dynamo/server.rb
@@ -11,7 +11,7 @@ module FakeDynamo
       status = 200
       content_type 'application/x-amz-json-1.0'
       begin
-        if ENV['throws'] == "1"
+        if settings.throws
           status = 400
           puts 'Whoops'
           raise ProvisionedThroughputExceededException

--- a/lib/fake_dynamo/server.rb
+++ b/lib/fake_dynamo/server.rb
@@ -12,6 +12,8 @@ module FakeDynamo
       content_type 'application/x-amz-json-1.0'
       begin
         if ENV['throws'] == "1"
+          status = 400
+          puts 'Whoops'
           raise ProvisionedThroughputExceededException
         end
         data = JSON.parse(request.body.read)

--- a/lib/fake_dynamo/server.rb
+++ b/lib/fake_dynamo/server.rb
@@ -11,6 +11,9 @@ module FakeDynamo
       status = 200
       content_type 'application/x-amz-json-1.0'
       begin
+        if ENV['throws'] == "1"
+          raise ProvisionedThroughputExceededException
+        end
         data = JSON.parse(request.body.read)
         operation = extract_operation(request.env)
         log.info "operation #{operation}"

--- a/lib/fake_dynamo/server.rb
+++ b/lib/fake_dynamo/server.rb
@@ -13,7 +13,7 @@ module FakeDynamo
       begin
         if settings.throws
           status = 400
-          puts 'Whoops'
+          log.info "Whoops!"
           raise ProvisionedThroughputExceededException
         end
         data = JSON.parse(request.body.read)


### PR DESCRIPTION
I needed to test my code's response to dynamodb's throttling behavior. I added a command line flag to force fake dynamo to always throw the ProvisionedThroughputExceededException.

Python developer here, my Ruby is poor, forgive me... :beers: 
